### PR TITLE
eipclient: Improve background thread handling

### DIFF
--- a/eeip/eipclient.py
+++ b/eeip/eipclient.py
@@ -88,7 +88,7 @@ class EEIPClient:
         if self.__tcpClient_socket is not None:
             self.__tcpClient_socket.settimeout(5)
             self.__tcpClient_socket.connect((address, port))
-            self.__thread = threading.Thread(target=self.__listen, args=())
+            self.__thread = threading.Thread(target=self.__listen, args=(), daemon=True)
             self.__thread.start()
             self.__tcpClient_socket.send(bytearray(__encapsulation.to_bytes()))
 
@@ -116,6 +116,8 @@ class EEIPClient:
             self.__stoplistening = True
             self.__tcpClient_socket.shutdown(socket.SHUT_RDWR)
             self.__tcpClient_socket.close()
+            if self.__thread is not None:
+                self.__thread.join()
         self.__session_handle = 0
 
 


### PR DESCRIPTION
* Run tcpClient background thread as a daemon. This is meant to prevent errors where eipclient unexpectedly leaves a thread hanging around after the process receives a SIGTERM.
* Handle exceptions in unregister_session so that it's less likely to throw